### PR TITLE
NuGet link fixed

### DIFF
--- a/docs/tools/generate.fsx
+++ b/docs/tools/generate.fsx
@@ -16,7 +16,7 @@ let info =
     "project-author", "Andrew Stevenson"
     "project-summary", "An F# type provider for DBpedia"
     "project-github", githubLink
-    "project-nuget", "http://nuget.com/packages/FSharp.Data.DbPedia" ]
+    "project-nuget", "https://www.nuget.org/packages/FSharp.Data.DbPedia" ]
 
 // --------------------------------------------------------------------------------------
 // For typical project, no changes are needed below


### PR DESCRIPTION
Link on the site is broken.
`nuget.org` should be instead of `nuget.com`

Could you please update the site and NuGet package?
